### PR TITLE
Redirect to Projects if Logged in

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -4,8 +4,10 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { redirectIfApiKeyExists } from '../redirects';
 import { setApiKey } from '../redux/actions/settings.actions';
 import { getApiKey } from '../redux/selectors/settings.selectors';
+import { wrapper } from '../redux/store';
 
 const Home = () => {
   const [key, setKey] = useState('');
@@ -42,5 +44,7 @@ const Home = () => {
     </Page>
   );
 };
+
+export const getServerSideProps = wrapper.getServerSideProps(redirectIfApiKeyExists);
 
 export default Home;

--- a/redirects.ts
+++ b/redirects.ts
@@ -1,6 +1,6 @@
 import { NextApiResponse } from 'next';
-import { Store } from 'redux';
 import { GetServerSidePropsContext } from 'next-redux-wrapper';
+import { Store } from 'redux';
 
 /** provids a server side redirect if you have no api key */
 export async function redirectIfNoApiKey(
@@ -12,9 +12,26 @@ export async function redirectIfNoApiKey(
 
   const state = store.getState();
 
-  if (!Boolean(state?.settings?.apiKey)) {
+  if (!state?.settings?.apiKey) {
     res.writeHead(301, {
       Location: '/',
+    });
+    res.end();
+  }
+}
+
+export async function redirectIfApiKeyExists(
+  context: GetServerSidePropsContext & {
+    store: Store;
+  }
+): Promise<void> {
+  const { store, res } = context;
+
+  const state = store.getState();
+
+  if (state?.settings?.apiKey) {
+    res.writeHead(301, {
+      Location: '/projects',
     });
     res.end();
   }


### PR DESCRIPTION
This is a super simple redirect to redirect from `/` to `/projects` on the server side. There's a client side redirect that I left in there that happens after entering API Key, but this will be if you're already logged in and go to /