### PR TITLE
fix(story modal): page was unscrollable after closing modal

### DIFF
--- a/components/StoryModal.tsx
+++ b/components/StoryModal.tsx
@@ -13,20 +13,25 @@ const StoryModal = (): JSX.Element => {
   const isOpen = useSelector(isStorySelected);
   const story = useSelector(getSelectedStory);
 
-  if (!isOpen) {
-    return <></>;
-  }
-
   return (
-    <Modal open={isOpen} key={story?.id} width="60%" onClose={() => dispatch(deselectStory())}>
-      <Modal.Title>{story.name}</Modal.Title>
-      <Modal.Content>
-        {story.description}
-        <Owners owners={story.owners} />
-        <Labels labels={story.labels} />
-        <Blockers blockers={story.blockers} />
-        <Comments comments={story.comments} />
-      </Modal.Content>
+    <Modal
+      open={isOpen}
+      width="60%"
+      onClose={() => {
+        dispatch(deselectStory());
+      }}>
+      {story && (
+        <>
+          <Modal.Title>{story.name}</Modal.Title>
+          <Modal.Content>
+            {story.description}
+            <Owners owners={story.owners} />
+            <Labels labels={story.labels} />
+            <Blockers blockers={story.blockers} />
+            <Comments comments={story.comments} />
+          </Modal.Content>
+        </>
+      )}
     </Modal>
   );
 };


### PR DESCRIPTION
Originally, if you open story card and then closes it, the whole page gets stuck in an unscrollable state.

Upon digging, the problem seems to be that the modal sets `overflow:hidden` on `body` when it opens, and if we just unmount the modal directly when closed, then the modal code does not have enough time to go through the closing animation and unset the `body`'s `overflow:hidden` style.

strictly speaking this is an issue in geist-ui's modal code - it should know to remove that style on unmount, but for now the workaround would be for us to keep the modal attached, and actually use open/close to control its visibility.