### PR TITLE
remove unnecessary spacing when content isn't present

### DIFF
--- a/components/Labels.tsx
+++ b/components/Labels.tsx
@@ -1,13 +1,16 @@
 import { Tag } from '@geist-ui/react';
-import { Label } from '../redux/types';
 import styled from 'styled-components';
+
+import { Label } from '../redux/types';
 
 interface LabelsParams {
   labels?: Label[];
   onClick?: (name: string, filter: Label) => void;
 }
 
-const getType = (name: string): 'default' | 'secondary' | 'success' | 'warning' | 'error' | 'dark' | 'lite' => {
+const getType = (
+  name: string
+): 'default' | 'secondary' | 'success' | 'warning' | 'error' | 'dark' | 'lite' => {
   if (name === 'medium' || name === 'med') {
     return 'warning';
   }
@@ -49,8 +52,7 @@ const Labels = ({ labels = [], onClick }: LabelsParams): JSX.Element => (
             type={getType(label.name)}
             onClick={(): void => onClick && onClick('labels', label)}
             title={label.name}
-            invert
-          >
+            invert>
             {label.name}
           </StyledTag>
         )

--- a/components/Owners.tsx
+++ b/components/Owners.tsx
@@ -1,22 +1,25 @@
-import { Spacer } from '@geist-ui/react';
-import { Fragment } from 'react';
+import styled from 'styled-components';
 
 import { Owner } from '../redux/types';
 import Person from './Person';
 
+const PersonContainer = styled.div`
+  display: ${props => props.display};
+`;
+
 interface OwnersParams {
   owners?: Owner[];
+  display?: string;
   onClick?: (name: string, filter: Owner) => void;
 }
 
-const Owners = ({ owners = [], onClick }: OwnersParams): JSX.Element => (
+const Owners = ({ owners = [], display = 'block', onClick }: OwnersParams): JSX.Element => (
   <>
     {owners.map(
       (owner: Owner): JSX.Element => (
-        <Fragment key={owner.id}>
+        <PersonContainer display={display} key={owner.id}>
           <Person person={owner} onClick={onClick} />
-          <Spacer y={1} />
-        </Fragment>
+        </PersonContainer>
       )
     )}
   </>

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -1,15 +1,15 @@
+import { Badge, Breadcrumbs, Card, Divider, Spacer, Text } from '@geist-ui/react';
 import { useState } from 'react';
-import styled from 'styled-components';
-import { Text, Spacer, Card, Divider, Badge, Breadcrumbs } from '@geist-ui/react';
 import { Draggable } from 'react-beautiful-dnd';
-
-import { Story, Owner, Label, Iteration } from '../redux/types';
 import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
+
 import { selectStory } from '../redux/actions/selectedStory.actions';
-import Owners from './Owners';
-import Labels from './Labels';
-import EstimateChangeDialog from './Dialogs/EstimateChangeDialog';
+import { Iteration, Label, Owner, Story } from '../redux/types';
 import Blockers from './Blockers';
+import EstimateChangeDialog from './Dialogs/EstimateChangeDialog';
+import Labels from './Labels';
+import Owners from './Owners';
 
 const CardContainer = styled(Card)(({ color }) => ({
   borderColor: `${color} !important`,
@@ -88,13 +88,23 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
                 <Spacer x={0.8} />
                 <Text b>{story.name}</Text>
               </Card.Content>
-              <Divider y={0} />
-              <Card.Content>
-                <Owners owners={story.owners} onClick={addFilter} />
-                <Labels labels={story.labels} onClick={addFilter} />
-                <Spacer y={0.5} />
-                <Blockers blockers={story.blockers} />
-              </Card.Content>
+              {Boolean(
+                story?.owners?.length || story?.labels?.length || story?.blockers?.length
+              ) && (
+                <>
+                  <Divider y={0} />
+                  <Card.Content>
+                    <Owners owners={story.owners} onClick={addFilter} />
+                    <Labels labels={story.labels} onClick={addFilter} />
+                    {Boolean(story?.blockers?.length) && (
+                      <>
+                        <Spacer y={0.5} />
+                        <Blockers blockers={story.blockers} />
+                      </>
+                    )}
+                  </Card.Content>
+                </>
+              )}
             </CardContainer>
             <Spacer y={1} />
           </div>

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -1,27 +1,26 @@
-import { useEffect, useState } from 'react';
-import styled from 'styled-components';
-import { Row, Loading, Col, useTheme } from '@geist-ui/react';
-import { useSelector, useDispatch } from 'react-redux';
-import { useRouter } from 'next/router';
-import { DragDropContext } from 'react-beautiful-dnd';
+import { Col, Loading, Row, useTheme } from '@geist-ui/react';
 import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { DragDropContext } from 'react-beautiful-dnd';
+import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
 
-import ProjectPicker from '../../components/ProjectPicker';
-import Owners from '../../components/Owners';
 import Column from '../../components/Column';
-import Labels from '../../components/Labels';
-import IterationPicker from '../../components/IterationPicker';
-import StoryModal from '../../components/StoryModal';
 import EstimateChangeDialog from '../../components/Dialogs/EstimateChangeDialog';
-
-import { useAsync } from '../../hooks';
+import IterationPicker from '../../components/IterationPicker';
+import Labels from '../../components/Labels';
+import Owners from '../../components/Owners';
+import ProjectPicker from '../../components/ProjectPicker';
+import StoryModal from '../../components/StoryModal';
 import PivotalHandler, { STORY_STATES } from '../../handlers/PivotalHandler';
-import { State, Story, Filters, Label, Owner, Iteration, UrlParams } from '../../redux/types';
+import { useAsync } from '../../hooks';
+import { redirectIfNoApiKey } from '../../redirects';
 import { addStories, moveStory } from '../../redux/actions/stories.actions';
 import { getApiKey } from '../../redux/selectors/settings.selectors';
 import { filterStories } from '../../redux/selectors/stories.selectors';
 import { wrapper } from '../../redux/store';
-import { redirectIfNoApiKey } from '../../redirects';
+import { Filters, Iteration, Label, Owner, State, Story, UrlParams } from '../../redux/types';
 import { spacing } from '../../styles';
 
 const Container = styled.div(({ color, image }) => ({
@@ -161,7 +160,7 @@ const Project: NextPage = (): JSX.Element => {
           removeIteration={() => removeFilter('iterations', null)}
         />
         <Labels labels={filters.labels} onClick={removeFilter} />
-        <Owners owners={filters.owners} onClick={removeFilter} />
+        <Owners owners={filters.owners} onClick={removeFilter} display="inline-block" />
       </FilterContainer>
 
       <Row gap={0.8}>


### PR DESCRIPTION
There were weird spacing around the `Owners`/`Labels`/`Blockers` area due to `Spacer`s that mount regardless of the content it is intending to space.

This PR removes usage / hides spacers behind conditionals.

the `display=blocker/inline-block` is a workaround that I'm putting in right now to allow showing one-per-line within the `StoryCard`, while showing them on the same row within the `FilterContainer`. I think in the long run it's better to split `Owners` up so those two touch-points can look differently (for example, adding an X button to the "person filter" on the top so it's clear clicking would remove).

Before:

<img width="876" alt="Screen Shot 2020-10-14 at 10 48 01 PM" src="https://user-images.githubusercontent.com/1354687/96082055-6561d080-0e6f-11eb-88e5-c9708ec70ff1.png">

After:

<img width="858" alt="Screen Shot 2020-10-14 at 10 47 03 PM" src="https://user-images.githubusercontent.com/1354687/96082047-5ed35900-0e6f-11eb-8227-ee0034df1c4b.png">

