### PR TITLE
State Refactor

### DIFF
--- a/components/AddComment.tsx
+++ b/components/AddComment.tsx
@@ -1,5 +1,4 @@
 import { Button, Textarea } from '@geist-ui/react';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -7,7 +6,8 @@ import PivotalHandler from '../handlers/PivotalHandler';
 import { useAsync } from '../hooks';
 import { editStory } from '../redux/actions/stories.actions';
 import { getApiKey } from '../redux/selectors/settings.selectors';
-import { Story, UrlParams } from '../redux/types';
+import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
+import { Story } from '../redux/types';
 
 interface AddCommentParams {
   story: Story;
@@ -16,16 +16,14 @@ interface AddCommentParams {
 const AddComment = ({ story }: AddCommentParams): JSX.Element => {
   const [comment, setComment] = useState<string>();
   const apiKey = useSelector(getApiKey);
-
-  const router = useRouter();
+  const projectId = useSelector(getSelectedProjectId);
   const dispatch = useDispatch();
-  const { id }: UrlParams = router.query;
 
   const [{ isLoading }, addComment] = useAsync(async () => {
-    await PivotalHandler.addComment({ apiKey, projectId: id, storyId: story.id, text: comment });
+    await PivotalHandler.addComment({ apiKey, projectId, storyId: story.id, text: comment });
     const newStory = await PivotalHandler.fetchStory({
       apiKey,
-      projectId: id,
+      projectId,
       storyId: story.id,
     });
     dispatch(editStory(newStory));

--- a/components/AddComment.tsx
+++ b/components/AddComment.tsx
@@ -28,7 +28,7 @@ const AddComment = ({ story }: AddCommentParams): JSX.Element => {
       projectId: id,
       storyId: story.id,
     });
-    dispatch(editStory({ projectId: id, story: newStory, storyState: newStory.current_state }));
+    dispatch(editStory(newStory));
     setComment('');
   });
 

--- a/components/AddComment.tsx
+++ b/components/AddComment.tsx
@@ -1,12 +1,10 @@
 import { Button, Textarea } from '@geist-ui/react';
 import { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import PivotalHandler from '../handlers/PivotalHandler';
-import { useAsync } from '../hooks';
+import { usePivotal } from '../hooks';
 import { editStory } from '../redux/actions/stories.actions';
-import { getApiKey } from '../redux/selectors/settings.selectors';
-import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
 import { Story } from '../redux/types';
 
 interface AddCommentParams {
@@ -15,11 +13,10 @@ interface AddCommentParams {
 
 const AddComment = ({ story }: AddCommentParams): JSX.Element => {
   const [comment, setComment] = useState<string>();
-  const apiKey = useSelector(getApiKey);
-  const projectId = useSelector(getSelectedProjectId);
+
   const dispatch = useDispatch();
 
-  const [{ isLoading }, addComment] = useAsync(async () => {
+  const [{ isLoading }, addComment] = usePivotal(async ({ apiKey, projectId }) => {
     await PivotalHandler.addComment({ apiKey, projectId, storyId: story.id, text: comment });
     const newStory = await PivotalHandler.fetchStory({
       apiKey,

--- a/components/Dialogs/EstimateChangeDialog.tsx
+++ b/components/Dialogs/EstimateChangeDialog.tsx
@@ -1,15 +1,15 @@
+import { Modal, Text } from '@geist-ui/react';
 import { useState } from 'react';
-import styled from 'styled-components';
-import { Text, Modal } from '@geist-ui/react';
-import { useRouter } from 'next/router';
 import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
 
-import EstimatePicker from '../EstimatePicker';
-import { Story, UrlParams } from '../../redux/types';
-import { editStory } from '../../redux/actions/stories.actions';
-import { getApiKey } from '../../redux/selectors/settings.selectors';
 import PivotalHandler from '../../handlers/PivotalHandler';
 import { useAsync } from '../../hooks';
+import { editStory } from '../../redux/actions/stories.actions';
+import { getApiKey } from '../../redux/selectors/settings.selectors';
+import { getSelectedProjectId } from '../../redux/selectors/stories.selectors';
+import { Story } from '../../redux/types';
+import EstimatePicker from '../EstimatePicker';
 
 const CenteredDiv = styled.div`
   display: flex;
@@ -33,21 +33,20 @@ const EstimateChangeDialog = ({
 }: EstimateChangeDialogParams): JSX.Element => {
   const dispatch = useDispatch();
   const apiKey = useSelector(getApiKey);
-  const router = useRouter();
-  const { id }: UrlParams = router.query;
+  const projectId = useSelector(getSelectedProjectId);
   const [selectedEstimate, setSelectedEstimate] = useState(
     story?.estimate ? String(story.estimate) : ''
   );
 
   const [{ isLoading }, changeEstimate] = useAsync(async () => {
-    const newStory: Story = { ...story, estimate: Number(selectedEstimate) };
-    dispatch(editStory({ projectId: id, story: newStory, storyState: state }));
-    await PivotalHandler.updateStory({
+    const newStory = await PivotalHandler.updateStory({
       apiKey,
-      projectId: id,
+      projectId: projectId,
       storyId: story.id,
       payload: { estimate: Number(selectedEstimate) },
     });
+
+    dispatch(editStory(newStory));
 
     onClose();
   });

--- a/components/Dialogs/EstimateChangeDialog.tsx
+++ b/components/Dialogs/EstimateChangeDialog.tsx
@@ -4,10 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import PivotalHandler from '../../handlers/PivotalHandler';
-import { useAsync } from '../../hooks';
+import { usePivotal } from '../../hooks';
 import { editStory } from '../../redux/actions/stories.actions';
-import { getApiKey } from '../../redux/selectors/settings.selectors';
-import { getSelectedProjectId } from '../../redux/selectors/stories.selectors';
 import { Story } from '../../redux/types';
 import EstimatePicker from '../EstimatePicker';
 
@@ -32,16 +30,14 @@ const EstimateChangeDialog = ({
   onClose,
 }: EstimateChangeDialogParams): JSX.Element => {
   const dispatch = useDispatch();
-  const apiKey = useSelector(getApiKey);
-  const projectId = useSelector(getSelectedProjectId);
   const [selectedEstimate, setSelectedEstimate] = useState(
     story?.estimate ? String(story.estimate) : ''
   );
 
-  const [{ isLoading }, changeEstimate] = useAsync(async () => {
+  const [{ isLoading }, changeEstimate] = usePivotal(async ({ apiKey, projectId }) => {
     const newStory = await PivotalHandler.updateStory({
       apiKey,
-      projectId: projectId,
+      projectId,
       storyId: story.id,
       payload: { estimate: Number(selectedEstimate) },
     });

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -9,7 +9,8 @@ import PivotalHandler from '../handlers/PivotalHandler';
 import { selectStory } from '../redux/actions/selectedStory.actions';
 import { clearNewStory, editStory, savedNewStory } from '../redux/actions/stories.actions';
 import { getApiKey } from '../redux/selectors/settings.selectors';
-import { Iteration, Label, Owner, Story, UrlParams } from '../redux/types';
+import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
+import { Iteration, Label, Owner, Story } from '../redux/types';
 import Blockers from './Blockers';
 import BlockersQuickView from './BlockersQuickView';
 import EstimateChangeDialog from './Dialogs/EstimateChangeDialog';
@@ -59,9 +60,7 @@ interface StoryCardParams {
 const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Element => {
   const dispatch = useDispatch();
   const apiKey = useSelector(getApiKey);
-
-  const router = useRouter();
-  const { id }: UrlParams = router.query;
+  const projectId = useSelector(getSelectedProjectId);
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [name, setName] = useState<string>(story.name);
@@ -71,7 +70,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     if (!name || escape.current) {
       escape.current = false;
       if (story.id === 'new') {
-        dispatch(clearNewStory(id));
+        dispatch(clearNewStory(projectId));
       } else {
         setName(story.name);
       }
@@ -81,13 +80,13 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     if (story.name !== name) {
       const newStory = await PivotalHandler.updateStory({
         apiKey: apiKey,
-        projectId: id,
+        projectId,
         storyId: story.id,
         payload: { name },
       });
 
       if (story.id === 'new') {
-        dispatch(savedNewStory(id, newStory));
+        dispatch(savedNewStory(projectId, newStory));
       } else {
         dispatch(editStory(newStory));
       }

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -1,7 +1,7 @@
 import { Badge, Breadcrumbs, Card, Divider, Spacer } from '@geist-ui/react';
 import { useRef, useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import PivotalHandler from '../handlers/PivotalHandler';

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -89,7 +89,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
       if (story.id === 'new') {
         dispatch(savedNewStory(id, newStory));
       } else {
-        dispatch(editStory({ projectId: id, story: newStory, storyState: story.current_state }));
+        dispatch(editStory(newStory));
       }
     }
   };

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -1,15 +1,13 @@
 import { Badge, Breadcrumbs, Card, Divider, Spacer } from '@geist-ui/react';
-import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import PivotalHandler from '../handlers/PivotalHandler';
+import { usePivotal } from '../hooks';
 import { selectStory } from '../redux/actions/selectedStory.actions';
 import { clearNewStory, editStory, savedNewStory } from '../redux/actions/stories.actions';
-import { getApiKey } from '../redux/selectors/settings.selectors';
-import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
 import { Iteration, Label, Owner, Story } from '../redux/types';
 import Blockers from './Blockers';
 import BlockersQuickView from './BlockersQuickView';
@@ -59,14 +57,12 @@ interface StoryCardParams {
 
 const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Element => {
   const dispatch = useDispatch();
-  const apiKey = useSelector(getApiKey);
-  const projectId = useSelector(getSelectedProjectId);
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [name, setName] = useState<string>(story.name);
   const escape = useRef(false); // we can't use setState for this as the dispatch of this takes an extra tick.
 
-  const saveName = async () => {
+  const [_, saveName] = usePivotal(async ({ apiKey, projectId }) => {
     if (!name || escape.current) {
       escape.current = false;
       if (story.id === 'new') {
@@ -79,7 +75,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
 
     if (story.name !== name) {
       const newStory = await PivotalHandler.updateStory({
-        apiKey: apiKey,
+        apiKey,
         projectId,
         storyId: story.id,
         payload: { name },
@@ -91,7 +87,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
         dispatch(editStory(newStory));
       }
     }
-  };
+  });
 
   const openEstimationModal = (e): void => {
     e.stopPropagation();

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -65,7 +65,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
   const [_, saveName] = usePivotal(async ({ apiKey, projectId }) => {
     if (!name || escape.current) {
       escape.current = false;
-      if (story.id === 'new') {
+      if (story.id === 'pending') {
         dispatch(clearNewStory(projectId));
       } else {
         setName(story.name);
@@ -81,7 +81,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
         payload: { name },
       });
 
-      if (story.id === 'new') {
+      if (story.id === 'pending') {
         dispatch(savedNewStory(projectId, newStory));
       } else {
         dispatch(editStory(newStory));

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,20 @@
+export const STORY_STATES = [
+  'unscheduled',
+  'unstarted',
+  'started',
+  'finished',
+  'delivered',
+  'rejected',
+  'accepted',
+];
+
+//anyone know a nifty way to convert the above array into the bottom structure?
+export const STORIES_BY_STATE = {
+  unscheduled: [],
+  unstarted: [],
+  started: [],
+  finished: [],
+  delivered: [],
+  rejected: [],
+  accepted: [],
+};

--- a/constants.js
+++ b/constants.js
@@ -8,13 +8,4 @@ export const STORY_STATES = [
   'accepted',
 ];
 
-//anyone know a nifty way to convert the above array into the bottom structure?
-export const STORIES_BY_STATE = {
-  unscheduled: [],
-  unstarted: [],
-  started: [],
-  finished: [],
-  delivered: [],
-  rejected: [],
-  accepted: [],
-};
+export const STORIES_BY_STATE = STORY_STATES.reduce((acc, state) => ({ ...acc, [state]: [] }), {});

--- a/handlers/PivotalHandler.ts
+++ b/handlers/PivotalHandler.ts
@@ -22,8 +22,7 @@ class PivotalHandler {
 
   // Gets all project stories for the provided user apiKey.
   static async fetchProjectStories({ apiKey, projectId }): Promise<Story[]> {
-    //todo: this may not be the best way to organize fetched stories - it may be better to sort on states rather then organize here.
-
+    //todo: change to one request using GET-REquest Aggrigator (https://www.pivotaltracker.com/help/api/#Using_the_GET_Request_Aggregator)
     const stories = await Promise.all(
       STORY_STATES.map(
         async (state: string): Promise<Story[]> => {

--- a/handlers/PivotalHandler.ts
+++ b/handlers/PivotalHandler.ts
@@ -1,16 +1,8 @@
 import { subDays } from 'date-fns';
 
+import { STORY_STATES } from '../constants';
 import { Project, Story } from '../redux/types';
 
-export const STORY_STATES = [
-  'unscheduled',
-  'unstarted',
-  'started',
-  'finished',
-  'delivered',
-  'rejected',
-  'accepted',
-];
 const PIVOTAL_API_URL = 'https://www.pivotaltracker.com/services/v5';
 
 const STORY_FIELDS =
@@ -29,32 +21,32 @@ class PivotalHandler {
   }
 
   // Gets all project stories for the provided user apiKey.
-  static async fetchProjectStories({ apiKey, projectId }): Promise<Record<string, Story[]>> {
+  static async fetchProjectStories({ apiKey, projectId }): Promise<Story[]> {
+    //todo: this may not be the best way to organize fetched stories - it may be better to sort on states rather then organize here.
+
     const stories = await Promise.all(
-      STORY_STATES.map(async state => {
-        let fetchString = `stories?limit=500&with_state=${state}&${STORY_FIELDS}`;
-        if (state === 'accepted') {
-          const oneWeekAgo = subDays(new Date(), 7);
-          fetchString = `${fetchString}&accepted_after=${oneWeekAgo.getTime()}`;
-        }
-
-        const request = await fetch(
-          `https://www.pivotaltracker.com/services/v5/projects/${projectId}/${fetchString}`,
-          {
-            headers: {
-              'X-TrackerToken': apiKey,
-            },
+      STORY_STATES.map(
+        async (state: string): Promise<Story[]> => {
+          let fetchString = `stories?limit=500&with_state=${state}&${STORY_FIELDS}`;
+          if (state === 'accepted') {
+            const oneWeekAgo = subDays(new Date(), 7);
+            fetchString = `${fetchString}&accepted_after=${oneWeekAgo.getTime()}`;
           }
-        );
-        return { [state]: await request.json() };
-      })
-    );
-    const normalizedStories = stories.reduce(
-      (acc, stateObject) => ({ ...acc, ...stateObject }),
-      {}
+
+          const request = await fetch(
+            `https://www.pivotaltracker.com/services/v5/projects/${projectId}/${fetchString}`,
+            {
+              headers: {
+                'X-TrackerToken': apiKey,
+              },
+            }
+          );
+          return request.json();
+        }
+      )
     );
 
-    return normalizedStories;
+    return stories.flat();
   }
 
   // Updates a single story.

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useAsync } from './useAsync';
+export { default as usePivotal } from './usePivotal';

--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export default (
   asyncFn,
   initialVal = {}
-): [{ result: any; isLoading: boolean; error: any }, Function] => {
+): [{ result: any; isLoading: boolean; error: any }, (...args) => void] => {
   const [result, setResult] = useState(initialVal);
   const [isLoading, setLoading] = useState(false);
   const [error, setError] = useState();

--- a/hooks/usePivotal.ts
+++ b/hooks/usePivotal.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { getApiKey } from '../redux/selectors/settings.selectors';
+import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
+
+const usePivotal = (
+  asyncFn,
+  initialVal = {}
+): [
+  { result: any; isLoading: boolean; error: any },
+  (apiKey: string, projectId: string) => void
+] => {
+  const [result, setResult] = useState(initialVal);
+  const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState();
+  const apiKey = useSelector(getApiKey);
+  const projectId = useSelector(getSelectedProjectId);
+
+  const doAsyncFn = async (...args) => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      setResult(await asyncFn({ apiKey, projectId }, ...args));
+    } catch (err) {
+      console.error(err);
+      setError(err);
+    }
+    setLoading(false);
+  };
+
+  return [{ result, isLoading, error }, doAsyncFn];
+};
+
+export default usePivotal;

--- a/hooks/usePivotal.ts
+++ b/hooks/usePivotal.ts
@@ -7,10 +7,7 @@ import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
 const usePivotal = (
   asyncFn,
   initialVal = {}
-): [
-  { result: any; isLoading: boolean; error: any },
-  (apiKey: string, projectId: string) => void
-] => {
+): [{ result: any; isLoading: boolean; error: any }, () => void] => {
   const [result, setResult] = useState(initialVal);
   const [isLoading, setLoading] = useState(false);
   const [error, setError] = useState();

--- a/hooks/usePivotal.ts
+++ b/hooks/usePivotal.ts
@@ -1,32 +1,16 @@
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getApiKey } from '../redux/selectors/settings.selectors';
 import { getSelectedProjectId } from '../redux/selectors/stories.selectors';
+import useAsync from './useAsync';
 
 const usePivotal = (
   asyncFn,
   initialVal = {}
-): [{ result: any; isLoading: boolean; error: any }, () => void] => {
-  const [result, setResult] = useState(initialVal);
-  const [isLoading, setLoading] = useState(false);
-  const [error, setError] = useState();
+): [{ result: any; isLoading: boolean; error: any }, (...args) => void] => {
   const apiKey = useSelector(getApiKey);
   const projectId = useSelector(getSelectedProjectId);
-
-  const doAsyncFn = async (...args) => {
-    setLoading(true);
-    setError(undefined);
-    try {
-      setResult(await asyncFn({ apiKey, projectId }, ...args));
-    } catch (err) {
-      console.error(err);
-      setError(err);
-    }
-    setLoading(false);
-  };
-
-  return [{ result, isLoading, error }, doAsyncFn];
+  return useAsync(() => asyncFn(apiKey, projectId), initialVal);
 };
 
 export default usePivotal;

--- a/hooks/usePivotal.ts
+++ b/hooks/usePivotal.ts
@@ -10,7 +10,7 @@ const usePivotal = (
 ): [{ result: any; isLoading: boolean; error: any }, (...args) => void] => {
   const apiKey = useSelector(getApiKey);
   const projectId = useSelector(getSelectedProjectId);
-  return useAsync(() => asyncFn(apiKey, projectId), initialVal);
+  return useAsync(() => asyncFn({ apiKey, projectId }), initialVal);
 };
 
 export default usePivotal;

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -14,7 +14,8 @@ import Labels from '../../components/Labels';
 import Owners from '../../components/Owners';
 import ProjectPicker from '../../components/ProjectPicker';
 import StoryModal from '../../components/StoryModal';
-import PivotalHandler, { STORY_STATES } from '../../handlers/PivotalHandler';
+import { STORY_STATES } from '../../constants';
+import PivotalHandler from '../../handlers/PivotalHandler';
 import { useAsync } from '../../hooks';
 import { redirectIfNoApiKey } from '../../redirects';
 import { addStories, moveStory, newStory } from '../../redux/actions/stories.actions';
@@ -91,7 +92,7 @@ const Project: NextPage = (): JSX.Element => {
     const getStories = async () => {
       const stories = await PivotalHandler.fetchProjectStories({ apiKey, projectId: id });
 
-      dispatch(addStories({ id, stories }));
+      dispatch(addStories(id, stories));
     };
     getStories();
   }, [id]);

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -121,7 +121,6 @@ const Project: NextPage = (): JSX.Element => {
 
     dispatch(
       moveStory({
-        projectId: id,
         sourceState,
         sourceIndex,
         destinationState,

--- a/redux/actions/stories.actions.ts
+++ b/redux/actions/stories.actions.ts
@@ -9,11 +9,6 @@ export const NEW_STORY = 'NEW_STORY';
 export const SAVED_NEW_STORY = 'SAVED_NEW_STORY';
 export const CLEAR_NEW_STORY = 'CLEAR_NEW_STORY';
 
-interface AddStories {
-  id: string;
-  stories: Record<string, Story[]>;
-}
-
 interface EditStory {
   projectId: string;
   storyState: string;
@@ -44,9 +39,10 @@ export const clearNewStory = (projectId: string): AnyAction => ({
   projectId,
 });
 
-export const addStories = (payload: AddStories): AnyAction => ({
+export const addStories = (projectId: string, stories: Story[]): AnyAction => ({
   type: ADD_STORIES,
-  payload,
+  projectId,
+  stories,
 });
 
 export const editStory = (payload: EditStory): AnyAction => ({

--- a/redux/actions/stories.actions.ts
+++ b/redux/actions/stories.actions.ts
@@ -46,5 +46,5 @@ export const editStory = (story: Story): AnyAction => ({
 
 export const moveStory = (payload: MoveStories): AnyAction => ({
   type: MOVE_STORY,
-  payload,
+  ...payload,
 });

--- a/redux/actions/stories.actions.ts
+++ b/redux/actions/stories.actions.ts
@@ -10,7 +10,6 @@ export const SAVED_NEW_STORY = 'SAVED_NEW_STORY';
 export const CLEAR_NEW_STORY = 'CLEAR_NEW_STORY';
 
 interface MoveStories {
-  projectId: string;
   sourceState: string;
   sourceIndex: number;
   destinationState: string;

--- a/redux/actions/stories.actions.ts
+++ b/redux/actions/stories.actions.ts
@@ -9,12 +9,6 @@ export const NEW_STORY = 'NEW_STORY';
 export const SAVED_NEW_STORY = 'SAVED_NEW_STORY';
 export const CLEAR_NEW_STORY = 'CLEAR_NEW_STORY';
 
-interface EditStory {
-  projectId: string;
-  storyState: string;
-  story: Story;
-}
-
 interface MoveStories {
   projectId: string;
   sourceState: string;
@@ -45,9 +39,9 @@ export const addStories = (projectId: string, stories: Story[]): AnyAction => ({
   stories,
 });
 
-export const editStory = (payload: EditStory): AnyAction => ({
+export const editStory = (story: Story): AnyAction => ({
   type: EDIT_STORY,
-  payload,
+  story,
 });
 
 export const moveStory = (payload: MoveStories): AnyAction => ({

--- a/redux/reducers/selectedStory.ts
+++ b/redux/reducers/selectedStory.ts
@@ -1,7 +1,6 @@
 import { AnyAction } from 'redux';
 
 import { DESELECT_STORY, SELECT_STORY } from '../actions/selectedStory.actions';
-import { EDIT_STORY } from '../actions/stories.actions';
 import { SelectedStory } from '../types';
 
 const initalState = {
@@ -11,15 +10,9 @@ const initalState = {
 const reducer = (state: SelectedStory = initalState, action: AnyAction): SelectedStory => {
   switch (action.type) {
     case SELECT_STORY:
-      return { selected: true, story: action.story };
+      return { selected: true, storyId: action.story.id };
     case DESELECT_STORY: {
       return { selected: false };
-    }
-    case EDIT_STORY: {
-      if (action.payload.story.id === state?.story?.id) {
-        return { ...state, story: action.payload.story };
-      }
-      return state;
     }
     default:
       return state;

--- a/redux/reducers/stories.ts
+++ b/redux/reducers/stories.ts
@@ -17,7 +17,6 @@ const initialState = {
 };
 
 const reducer = (state: StoriesState = initialState, action: AnyAction) => {
-  console.log('got action', action, state);
   const actionWithProjectId = { ...action, projectId: state.selectedProjectId };
 
   switch (action.type) {

--- a/redux/reducers/stories.ts
+++ b/redux/reducers/stories.ts
@@ -17,8 +17,9 @@ const initialState = {
 };
 
 const reducer = (state: StoriesState = initialState, action: AnyAction) => {
-  console.log('got action', action);
-  const actionWithProjectId = { ...action, projectId: state.seletedProjectId };
+  console.log('got action', action, state);
+  const actionWithProjectId = { ...action, projectId: state.selectedProjectId };
+
   switch (action.type) {
     case NEW_STORY: {
       const pending = {
@@ -91,46 +92,12 @@ const reducer = (state: StoriesState = initialState, action: AnyAction) => {
       };
     }
 
-    // case MOVE_STORY: {
-    //   const {
-    //     projectId,
-    //     sourceState,
-    //     sourceIndex,
-    //     destinationState,
-    //     destinationIndex,
-    //   } = action.payload;
-    //   const story: Story = state[projectId][sourceState][sourceIndex];
-    //   const sourceArr: Story[] = state[projectId][sourceState].filter(item => item.id !== story.id);
-
-    //   if (sourceState === destinationState) {
-    //     // If we are moving the story order in the same column, just reorganize the same array.
-    //     return {
-    //       ...state,
-    //       [projectId]: {
-    //         ...state[projectId],
-    //         [sourceState]: [
-    //           ...sourceArr.slice(0, destinationIndex),
-    //           story,
-    //           ...sourceArr.slice(destinationIndex),
-    //         ],
-    //       },
-    //     };
-    //   }
-    //   const draggedArr: Story[] = state[projectId][destinationState];
-    //   // If the story is dragged between columns, we need to adjust both states items.
-    //   return {
-    //     ...state,
-    //     [projectId]: {
-    //       ...state[projectId],
-    //       [sourceState]: sourceArr,
-    //       [destinationState]: [
-    //         ...draggedArr.slice(0, destinationIndex),
-    //         story,
-    //         ...draggedArr.slice(destinationIndex),
-    //       ],
-    //     },
-    //   };
-    // }
+    case MOVE_STORY: {
+      return {
+        ...state,
+        byProject: byProjectReducer(state.byProject, actionWithProjectId),
+      };
+    }
     default:
       return state;
   }

--- a/redux/reducers/stories.ts
+++ b/redux/reducers/stories.ts
@@ -34,7 +34,6 @@ const reducer = (state: StoriesState = initialState, action: AnyAction) => {
           ...state.byId,
           pending,
         },
-        //todo: I should probably slice this state out into its own reducer (byProject);
         byProject: byProjectReducer(state.byProject, actionWithProjectId),
       };
     }

--- a/redux/reducers/stories.ts
+++ b/redux/reducers/stories.ts
@@ -77,17 +77,19 @@ const reducer = (state: StoriesState = initialState, action: AnyAction) => {
         selectedProjectId: action.projectId,
       };
     }
-    // case EDIT_STORY: {
-    //   const { projectId, story, storyState } = action.payload;
-    //   const storyStateArr: Story[] = state[projectId][storyState];
-    //   const storyIndex: number = storyStateArr.findIndex(element => element.id === story.id);
-    //   const storiesArr: Story[] = [
-    //     ...storyStateArr.slice(0, storyIndex),
-    //     story,
-    //     ...storyStateArr.slice(storyIndex + 1),
-    //   ];
-    //   return { ...state, [projectId]: { ...state[projectId], [storyState]: storiesArr } };
-    // }
+    case EDIT_STORY: {
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          [action.story.id]: action.story,
+        },
+        byProject: byProjectReducer(state.byProject, {
+          ...actionWithProjectId,
+          oldStory: state.byId[action.story.id],
+        }),
+      };
+    }
 
     // case MOVE_STORY: {
     //   const {

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -85,7 +85,6 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
     }
 
     case MOVE_STORY: {
-      console.log('got move story', action);
       const { projectId, sourceState, sourceIndex, destinationState, destinationIndex } = action;
       const storyId: string = state[projectId].storyIdsByState[sourceState][sourceIndex];
       const sourceWithoutStory: string[] = state[projectId].storyIdsByState[sourceState].filter(

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -75,17 +75,14 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
         },
       };
     }
-    //     case EDIT_STORY: {
-    //       const { projectId, story, storyState } = action.payload;
-    //       const storyStateArr: Story[] = state[projectId][storyState];
-    //       const storyIndex: number = storyStateArr.findIndex(element => element.id === story.id);
-    //       const storiesArr: Story[] = [
-    //         ...storyStateArr.slice(0, storyIndex),
-    //         story,
-    //         ...storyStateArr.slice(storyIndex + 1),
-    //       ];
-    //       return { ...state, [projectId]: { ...state[projectId], [storyState]: storiesArr } };
-    //     }
+    case EDIT_STORY: {
+      if (action.story.state !== action.oldStory.state) {
+        //todo: the story has moved on the server, we should remove it from the previous bucket,
+        //otherwise, the story is fine.
+      }
+
+      return state;
+    }
 
     //     case MOVE_STORY: {
     //       const {

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -1,0 +1,135 @@
+import { AnyAction } from 'redux';
+
+import { STORIES_BY_STATE } from '../../../constants';
+import {
+  ADD_STORIES,
+  CLEAR_NEW_STORY,
+  EDIT_STORY,
+  MOVE_STORY,
+  NEW_STORY,
+  SAVED_NEW_STORY,
+} from '../../actions/stories.actions';
+import { Story } from '../../types';
+import { StoriesByProject } from '../../types';
+
+const initialState = {};
+
+const reducer = (state: Record<string, StoriesByProject> = initialState, action: AnyAction) => {
+  switch (action.type) {
+    case NEW_STORY: {
+      return {
+        ...state,
+        [action.projectId]: {
+          storyIdsByState: {
+            ...state[action.projectId].storyIdsByState,
+            unscheduled: ['pending', ...state[action.projectId].storyIdsByState.unscheduled],
+          },
+        },
+      };
+    }
+    case SAVED_NEW_STORY: {
+      //clears the the story new story as well as adds a new story into state.
+      const unscheduledStories = state[action.projectId].storyIdsByState.unscheduled.filter(
+        id => id !== 'pending'
+      );
+
+      return {
+        ...state,
+        [action.projectId]: {
+          storyIdsByState: {
+            ...state[action.projectId].storyIdsByState,
+            unscheduled: [action.story.id, ...unscheduledStories],
+          },
+        },
+      };
+    }
+    case CLEAR_NEW_STORY: {
+      return {
+        ...state,
+        [action.projectId]: {
+          storyIdsByState: {
+            ...state[action.projectId].storyIdsByState,
+            unscheduled: [
+              ...state[action.projectId].storyIdsByState.unscheduled.filter(id => id !== 'pending'),
+            ],
+          },
+        },
+      };
+    }
+
+    //todo: do all the addStories and stuff.
+    case ADD_STORIES: {
+      const storiesByState = action.stories.reduce(
+        (stories: Record<string, string[]>, story: Story) => {
+          return { ...stories, [story.current_state]: [...stories[story.current_state], story.id] };
+        },
+        STORIES_BY_STATE
+      );
+
+      return {
+        ...state,
+        [action.projectId]: {
+          storyIdsByState: {
+            ...storiesByState,
+          },
+        },
+      };
+    }
+    //     case EDIT_STORY: {
+    //       const { projectId, story, storyState } = action.payload;
+    //       const storyStateArr: Story[] = state[projectId][storyState];
+    //       const storyIndex: number = storyStateArr.findIndex(element => element.id === story.id);
+    //       const storiesArr: Story[] = [
+    //         ...storyStateArr.slice(0, storyIndex),
+    //         story,
+    //         ...storyStateArr.slice(storyIndex + 1),
+    //       ];
+    //       return { ...state, [projectId]: { ...state[projectId], [storyState]: storiesArr } };
+    //     }
+
+    //     case MOVE_STORY: {
+    //       const {
+    //         projectId,
+    //         sourceState,
+    //         sourceIndex,
+    //         destinationState,
+    //         destinationIndex,
+    //       } = action.payload;
+    //       const story: Story = state[projectId][sourceState][sourceIndex];
+    //       const sourceArr: Story[] = state[projectId][sourceState].filter(item => item.id !== story.id);
+
+    //       if (sourceState === destinationState) {
+    //         // If we are moving the story order in the same column, just reorganize the same array.
+    //         return {
+    //           ...state,
+    //           [projectId]: {
+    //             ...state[projectId],
+    //             [sourceState]: [
+    //               ...sourceArr.slice(0, destinationIndex),
+    //               story,
+    //               ...sourceArr.slice(destinationIndex),
+    //             ],
+    //           },
+    //         };
+    //       }
+    //       const draggedArr: Story[] = state[projectId][destinationState];
+    //       // If the story is dragged between columns, we need to adjust both states items.
+    //       return {
+    //         ...state,
+    //         [projectId]: {
+    //           ...state[projectId],
+    //           [sourceState]: sourceArr,
+    //           [destinationState]: [
+    //             ...draggedArr.slice(0, destinationIndex),
+    //             story,
+    //             ...draggedArr.slice(destinationIndex),
+    //           ],
+    //         },
+    //       };
+    //     }
+    //     default:
+    //       return state;
+  }
+};
+
+export default reducer;

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -57,7 +57,6 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
       };
     }
 
-    //todo: do all the addStories and stuff.
     case ADD_STORIES: {
       const storiesByState = action.stories.reduce(
         (stories: Record<string, string[]>, story: Story) => {

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -76,56 +76,59 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
       };
     }
     case EDIT_STORY: {
-      if (action.story.state !== action.oldStory.state) {
-        //todo: the story has moved on the server, we should remove it from the previous bucket,
-        //otherwise, the story is fine.
-      }
+      //   if (action.story.state !== action.oldStory.state) {
+      //     //todo: the story has moved on the server, we should remove it from the previous bucket,
+      //     //otherwise, the story is fine.
+      //   }
 
       return state;
     }
 
-    //     case MOVE_STORY: {
-    //       const {
-    //         projectId,
-    //         sourceState,
-    //         sourceIndex,
-    //         destinationState,
-    //         destinationIndex,
-    //       } = action.payload;
-    //       const story: Story = state[projectId][sourceState][sourceIndex];
-    //       const sourceArr: Story[] = state[projectId][sourceState].filter(item => item.id !== story.id);
+    case MOVE_STORY: {
+      console.log('got move story', action);
+      const { projectId, sourceState, sourceIndex, destinationState, destinationIndex } = action;
+      const storyId: string = state[projectId].storyIdsByState[sourceState][sourceIndex];
+      const sourceWithoutStory: string[] = state[projectId].storyIdsByState[sourceState].filter(
+        (id: string): boolean => id !== storyId
+      );
 
-    //       if (sourceState === destinationState) {
-    //         // If we are moving the story order in the same column, just reorganize the same array.
-    //         return {
-    //           ...state,
-    //           [projectId]: {
-    //             ...state[projectId],
-    //             [sourceState]: [
-    //               ...sourceArr.slice(0, destinationIndex),
-    //               story,
-    //               ...sourceArr.slice(destinationIndex),
-    //             ],
-    //           },
-    //         };
-    //       }
-    //       const draggedArr: Story[] = state[projectId][destinationState];
-    //       // If the story is dragged between columns, we need to adjust both states items.
-    //       return {
-    //         ...state,
-    //         [projectId]: {
-    //           ...state[projectId],
-    //           [sourceState]: sourceArr,
-    //           [destinationState]: [
-    //             ...draggedArr.slice(0, destinationIndex),
-    //             story,
-    //             ...draggedArr.slice(destinationIndex),
-    //           ],
-    //         },
-    //       };
-    //     }
-    //     default:
-    //       return state;
+      if (sourceState === destinationState) {
+        // If we are moving the story order in the same column, just reorganize the same array.
+        return {
+          ...state,
+          [projectId]: {
+            ...state[projectId],
+            storyIdsByState: {
+              ...state[projectId].storyIdsByState,
+              [sourceState]: [
+                ...sourceWithoutStory.slice(0, destinationIndex),
+                storyId,
+                ...sourceWithoutStory.slice(destinationIndex),
+              ],
+            },
+          },
+        };
+      }
+      const destinationStateList: string[] = state[projectId].storyIdsByState[destinationState];
+      // If the story is dragged between columns, we need to adjust both states items.
+      return {
+        ...state,
+        [projectId]: {
+          ...state[projectId],
+          storyIdsByState: {
+            ...state[projectId].storyIdsByState,
+            [sourceState]: sourceWithoutStory,
+            [destinationState]: [
+              ...destinationStateList.slice(0, destinationIndex),
+              storyId,
+              ...destinationStateList.slice(destinationIndex),
+            ],
+          },
+        },
+      };
+    }
+    default:
+      return state;
   }
 };
 

--- a/redux/selectors/selectedStory.selectors.ts
+++ b/redux/selectors/selectedStory.selectors.ts
@@ -1,7 +1,7 @@
 import { State, Story } from '../types';
 
 export const getSelectedStory = (state: State): Story => {
-  return state.selectedStory?.story;
+  return state.stories.byId[state.selectedStory?.storyId];
 };
 
 export const isStorySelected = (state: State): boolean => {

--- a/redux/selectors/stories.selectors.ts
+++ b/redux/selectors/stories.selectors.ts
@@ -1,5 +1,9 @@
 import { State, Story } from '../types';
 
+export const getSelectedProjectId = (state: State): string => {
+  return state.stories.selectedProjectId;
+};
+
 export const filterStories = (
   state: State,
   projectId: string,

--- a/redux/selectors/stories.selectors.ts
+++ b/redux/selectors/stories.selectors.ts
@@ -49,14 +49,13 @@ export const filterStories = (
   }
 
   //now map all these stories.
-  const stories = Object.keys(storyIdsByState).reduce((total, state) => {
-    total[state] = storyIdsByState[state].map(
-      (storyId: string): Story => {
-        return byId[storyId];
-      }
-    );
-    return total;
-  }, {});
+  const stories = Object.keys(storyIdsByState).reduce(
+    (total, state) => ({
+      ...total,
+      [state]: storyIdsByState[state].map((storyId: string): Story => byId[storyId]),
+    }),
+    {}
+  );
 
   return stories;
 };

--- a/redux/selectors/stories.selectors.ts
+++ b/redux/selectors/stories.selectors.ts
@@ -1,7 +1,17 @@
 import { State, Story } from '../types';
 
-export const filterStories = (state: State, id: string, filters: {}): Record<string, Story[]> => {
-  let stories = state.stories[id];
+export const filterStories = (
+  state: State,
+  projectId: string,
+  filters: any //for now
+): Record<string, Story[]> => {
+  let storyIdsByState = state.stories.byProject[projectId]?.storyIdsByState;
+
+  if (!storyIdsByState) {
+    return null;
+  }
+
+  const byId = state.stories.byId;
 
   /** Filtering is AND based filtering **/
   for (const filter of Object.keys(filters)) {
@@ -9,16 +19,19 @@ export const filterStories = (state: State, id: string, filters: {}): Record<str
       const selectedStories = filters[filter].stories.map((s: Story): string => s.id);
       const filteredStories = {};
 
-      for (const status of Object.keys(stories)) {
-        filteredStories[status] = stories[status].filter((story: Story): boolean => selectedStories.includes(story.id));
+      for (const state of Object.keys(storyIdsByState)) {
+        filteredStories[state] = storyIdsByState[state].filter((storyId: string): boolean =>
+          selectedStories.includes(storyId)
+        );
       }
-      stories = { ...filteredStories };
+      storyIdsByState = { ...filteredStories };
       continue;
     }
     for (const label of filters[filter]) {
       const filteredStories = {};
-      for (const status of Object.keys(stories)) {
-        filteredStories[status] = stories[status].filter((story: Story): boolean => {
+      for (const status of Object.keys(storyIdsByState)) {
+        filteredStories[status] = storyIdsByState[status].filter((storyId: string): boolean => {
+          const story = byId[storyId];
           for (const thisLabel of story[filter]) {
             if (thisLabel.id == label.id) {
               return true;
@@ -27,9 +40,19 @@ export const filterStories = (state: State, id: string, filters: {}): Record<str
           return false;
         });
       }
-      stories = { ...filteredStories };
+      storyIdsByState = { ...filteredStories };
     }
   }
+
+  //now map all these stories.
+  const stories = Object.keys(storyIdsByState).reduce((total, state) => {
+    total[state] = storyIdsByState[state].map(
+      (storyId: string): Story => {
+        return byId[storyId];
+      }
+    );
+    return total;
+  }, {});
 
   return stories;
 };

--- a/redux/store.ts
+++ b/redux/store.ts
@@ -1,22 +1,29 @@
 // store.ts
-import { createStore, AnyAction, combineReducers } from 'redux';
-import { MakeStore, createWrapper, Context } from 'next-redux-wrapper';
-import { State } from './types';
-import projects from './reducers/projects';
-import stories from './reducers/stories';
-import iterations from './reducers/iterations';
-import settings from './reducers/settings';
-import selectedStory from './reducers/selectedStory';
+import { Context, createWrapper, MakeStore } from 'next-redux-wrapper';
+import { AnyAction, combineReducers, createStore } from 'redux';
 
-const makeStore: MakeStore<State> = (context: Context) =>
-  createStore(
+import iterations from './reducers/iterations';
+import projects from './reducers/projects';
+import selectedStory from './reducers/selectedStory';
+import settings from './reducers/settings';
+import stories from './reducers/stories';
+import { State } from './types';
+
+const makeStore: MakeStore<State> = (context: Context) => {
+  const ext =
+    typeof window !== 'undefined' &&
+    window['__REDUX_DEVTOOLS_EXTENSION__'] &&
+    window['__REDUX_DEVTOOLS_EXTENSION__']();
+  return createStore(
     combineReducers({
       projects,
       stories,
       iterations,
       settings,
       selectedStory,
-    })
+    }),
+    ext
   );
+};
 
 export const wrapper = createWrapper<State>(makeStore, { debug: true });

--- a/redux/types.ts
+++ b/redux/types.ts
@@ -9,7 +9,7 @@ export interface StoriesState {
   byId: Record<string, Story>;
   byProject: Record<string, StoriesByProject>;
   selectedStoryId?: string;
-  seletedProjectId?: string;
+  selectedProjectId?: string;
 }
 
 export interface StoriesByProject {

--- a/redux/types.ts
+++ b/redux/types.ts
@@ -1,9 +1,20 @@
 export interface State {
   projects?: Project[];
-  stories?: Record<string, Record<string, Story[]>>;
+  stories?: StoriesState;
   iterations?: Record<number, Set<Iteration>>;
   settings?: Settings;
-  selectedStory?: SelectedStory;
+}
+
+export interface StoriesState {
+  byId: Record<string, Story>;
+  byProject: Record<string, StoriesByProject>;
+  selectedStoryId?: string;
+  seletedProjectId?: string;
+}
+
+export interface StoriesByProject {
+  storyIdsByState: Record<string, string[]>;
+  // storyIdsByMilestone: Record<string, string[]>;
 }
 
 export interface Project {

--- a/redux/types.ts
+++ b/redux/types.ts
@@ -3,6 +3,12 @@ export interface State {
   stories?: StoriesState;
   iterations?: Record<number, Set<Iteration>>;
   settings?: Settings;
+  selectedStory: SelectedStory;
+}
+
+export interface SelectedStory {
+  storyId?: string;
+  selected: boolean;
 }
 
 export interface StoriesState {


### PR DESCRIPTION
The goals here with this refactor:

1. Provide a quick ease of access for any story (byId) in state, and extract organization out.
2. Remove need for selectedStory in its own reducer
3. Seperate logic for how we organize the board in its own reducer, so we can make another reducer later for by Milestone
4. Store projectId in state, and remove this from components needing to call server.

I've limited the refactor for now to what's in here, and will follow up with other PRs