### PR TITLE
feat(components/StoryCard): optimize padding, full col width for better desktop UX

### DIFF
--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -51,7 +51,9 @@ const Title = styled.textarea`
 `;
 
 // Used to override Card.Content's default 16pt padding
-const contentStyle = { padding: '12pt' };
+const CardContent = styled(Card.Content)`
+  padding: 0 !important;
+`;
 
 interface StoryCardParams {
   story: Story;
@@ -119,7 +121,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
                 }
                 dispatch(selectStory(story));
               }}>
-              <Card.Content style={contentStyle}>
+              <CardContent>
                 {Boolean(story?.blockers?.length) && (
                   <div
                     style={{
@@ -176,14 +178,15 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
                   }}
                   onBlur={saveName}
                 />
-              </Card.Content>
+              </CardContent>
               {Boolean(story?.owners?.length || story?.labels?.length) && (
                 <>
                   <Divider y={0} />
-                  <Card.Content>
+                  <Spacer y={0.5} />
+                  <CardContent>
                     <Owners owners={story.owners} onClick={addFilter} />
                     <Labels labels={story.labels} onClick={addFilter} />
-                  </Card.Content>
+                  </CardContent>
                 </>
               )}
             </CardContainer>

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -42,12 +42,16 @@ const StyledSpan = styled.span`
 `;
 
 const Title = styled.textarea`
+  width: 100%;
   border: none;
   font-weight: 500;
   overflow: hidden;
   resize: none;
   background: none;
 `;
+
+// Used to override Card.Content's default 16pt padding
+const contentStyle = { padding: '12pt' };
 
 interface StoryCardParams {
   story: Story;
@@ -108,7 +112,6 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
             {...provided.dragHandleProps}
             ref={provided.innerRef}>
             <CardContainer
-              width="250px"
               hoverable
               onClick={e => {
                 if (['A', 'SPAN', 'TEXTAREA'].includes(e.target.nodeName)) {
@@ -116,7 +119,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
                 }
                 dispatch(selectStory(story));
               }}>
-              <Card.Content>
+              <Card.Content style={contentStyle}>
                 {Boolean(story?.blockers?.length) && (
                   <div
                     style={{

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,9 +15,10 @@ import { darkTheme, lightTheme } from '../themes';
 const OpticTracker = ({ Component, pageProps }: AppProps): JSX.Element => {
   const selectedTheme = useSelector(getTheme);
   const theme = selectedTheme === 'light' ? lightTheme : darkTheme;
+  const scTheme = useTheme();
   return (
     <GeistProvider theme={theme}>
-      <SCThemeProvider theme={() => useTheme()}>
+      <SCThemeProvider theme={scTheme}>
         <CssBaseline />
         <Nav />
         <Component {...pageProps} toggleLight />


### PR DESCRIPTION
## Description
PR handles 2 tweaks:
- move useTheme hook call outside of return to remove console warning (see screenshot)
- use card content more efficiently by reducing built-in default padding
before
![Screen Shot 2020-10-16 at 6 19 55 PM](https://user-images.githubusercontent.com/12281609/96321241-a7f7ea00-0fe2-11eb-8ec9-016c07cd4964.png)
after
![Screen Shot 2020-10-16 at 6 31 21 PM](https://user-images.githubusercontent.com/12281609/96321245-acbc9e00-0fe2-11eb-8d32-827296d5e989.png)
Chopped story cards
![Screen Shot 2020-10-16 at 6 58 15 PM](https://user-images.githubusercontent.com/12281609/96321247-ae866180-0fe2-11eb-838e-08dcd18f9ca8.png)
Full width story cards, optimized padding
![Screen Shot 2020-10-16 at 6 58 25 PM](https://user-images.githubusercontent.com/12281609/96321251-b0e8bb80-0fe2-11eb-875b-67800ec7ca1f.png)
