### PR TITLE
Milestone View

### DIFF
--- a/components/Column.tsx
+++ b/components/Column.tsx
@@ -43,6 +43,10 @@ const colors = {
   delivered: '#62dbc8',
   rejected: '#ff5757',
   accepted: '#7cd651',
+  backlog: '#ad6fff',
+  'milestone 1': '#4ebafd',
+  'milestone 2': '#ffd14d',
+  'milestone 3': '#ff8d48',
 };
 
 const Column = ({ idx, state, stories, addFilter }: ColumnParams): JSX.Element => {

--- a/components/ModePicker.tsx
+++ b/components/ModePicker.tsx
@@ -18,7 +18,6 @@ const ModePicker = (): JSX.Element => {
       width="200px"
       value={storyMode}
       onChange={value => {
-        console.log('changing value to', value);
         const mode = Array.isArray(value) ? value[0] : value;
         dispatch(toggleMode(mode));
       }}>

--- a/components/ModePicker.tsx
+++ b/components/ModePicker.tsx
@@ -1,0 +1,36 @@
+import { Select } from '@geist-ui/react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { toggleMode } from '../redux/actions/stories.actions';
+import { getSelectedProjectMode } from '../redux/selectors/stories.selectors';
+import { StoryModes } from '../redux/types';
+
+/**
+ * Selects mode of the board.
+ */
+const ModePicker = (): JSX.Element => {
+  const storyMode = useSelector(getSelectedProjectMode);
+  const dispatch = useDispatch();
+
+  return (
+    <Select
+      disableMatchWidth
+      width="200px"
+      value={storyMode}
+      onChange={value => {
+        console.log('changing value to', value);
+        const mode = Array.isArray(value) ? value[0] : value;
+        dispatch(toggleMode(mode));
+      }}>
+      {Object.values(StoryModes).map(mode => {
+        return (
+          <Select.Option key={mode} id={mode} value={mode}>
+            {mode}
+          </Select.Option>
+        );
+      })}
+    </Select>
+  );
+};
+
+export default ModePicker;

--- a/constants.js
+++ b/constants.js
@@ -8,7 +8,14 @@ export const STORY_STATES = [
   'accepted',
 ];
 
+export const STORY_MILESTONES = ['backlog', 'milestone 1', 'milestone 2', 'milestone 3'];
+
 export const STORIES_BY_STATE = STORY_STATES.reduce((acc, state) => ({ ...acc, [state]: [] }), {});
+
+export const STORIES_BY_MILESTONE = STORY_MILESTONES.reduce(
+  (acc, state) => ({ ...acc, [state]: [] }),
+  {}
+);
 
 export const UNESTIMATED_STORY_TYPES = ['bug', 'chore'];
 

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -133,7 +133,14 @@ const Project: NextPage = (): JSX.Element => {
       const destinationMilestone = STORY_MILESTONES[destinationDroppableId];
       const story = stories[sourceMilestone][sourceIndex];
 
-      //todo: this is where we add the label then run update where we trigger the move.
+      dispatch(
+        moveStory({
+          sourceState: sourceMilestone,
+          sourceIndex,
+          destinationState: destinationMilestone,
+          destinationIndex,
+        })
+      );
       const updatedStory = await PivotalHandler.updateStory({
         apiKey,
         projectId: id,
@@ -150,14 +157,6 @@ const Project: NextPage = (): JSX.Element => {
           ],
         },
       });
-      dispatch(
-        moveStory({
-          sourceState: sourceMilestone,
-          sourceIndex,
-          destinationState: destinationMilestone,
-          destinationIndex,
-        })
-      );
       dispatch(editStory(updatedStory));
       return;
     }

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -107,7 +107,6 @@ const Project: NextPage = (): JSX.Element => {
   }, [id]);
 
   const [, onDragEnd] = useAsync(async (result: DragDropContext.result) => {
-    console.log('got result', result);
     const { source, destination, draggableId } = result;
 
     const { droppableId: sourceDroppableId, index: sourceIndex } = source || {};

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -11,11 +11,13 @@ import Column from '../../components/Column';
 import EstimateChangeDialog from '../../components/Dialogs/EstimateChangeDialog';
 import IterationPicker from '../../components/IterationPicker';
 import Labels from '../../components/Labels';
+import ModePicker from '../../components/ModePicker';
 import Owners from '../../components/Owners';
 import ProjectPicker from '../../components/ProjectPicker';
 import StoryModal from '../../components/StoryModal';
 import {
   ESTIMATE_NOT_REQUIRED_STATES,
+  STORY_MILESTONES,
   STORY_STATES,
   UNESTIMATED_STORY_TYPES,
 } from '../../constants';
@@ -24,7 +26,7 @@ import { useAsync } from '../../hooks';
 import { redirectIfNoApiKey } from '../../redirects';
 import { addStories, moveStory, newStory } from '../../redux/actions/stories.actions';
 import { getApiKey } from '../../redux/selectors/settings.selectors';
-import { filterStories } from '../../redux/selectors/stories.selectors';
+import { filterStories, getSelectedProjectMode } from '../../redux/selectors/stories.selectors';
 import { wrapper } from '../../redux/store';
 import { Filters, Iteration, Label, Owner, State, Story, UrlParams } from '../../redux/types';
 import { spacing } from '../../styles';
@@ -59,6 +61,8 @@ const Project: NextPage = (): JSX.Element => {
   const stories = useSelector(
     (state: State): Record<string, Story[]> => filterStories(state, id, filters)
   );
+  const mode = useSelector(getSelectedProjectMode);
+  const selectedModeStates = mode === 'Milestone' ? STORY_MILESTONES : STORY_STATES;
 
   const getFilterArray = (filters: Owner[] | Label[] = [], filter: Owner | Label) => {
     if (filters.find(f => f.name === filter.name)) {
@@ -178,6 +182,7 @@ const Project: NextPage = (): JSX.Element => {
           addIteration={val => addFilter('iterations', val)}
           removeIteration={() => removeFilter('iterations', null)}
         />
+        <ModePicker />
         <Labels labels={filters.labels} onClick={removeFilter} />
         <Owners owners={filters.owners} onClick={removeFilter} display="inline-block" />
       </FilterContainer>
@@ -190,7 +195,7 @@ const Project: NextPage = (): JSX.Element => {
         )}
         {!loading && (
           <DragDropContext onDragEnd={onDragEnd}>
-            {STORY_STATES.map((state: string, idx: number) => (
+            {selectedModeStates.map((state: string, idx: number) => (
               <Column
                 key={state}
                 state={state}

--- a/redux/actions/stories.actions.ts
+++ b/redux/actions/stories.actions.ts
@@ -8,6 +8,7 @@ export const EDIT_STORY = 'EDIT_STORY';
 export const NEW_STORY = 'NEW_STORY';
 export const SAVED_NEW_STORY = 'SAVED_NEW_STORY';
 export const CLEAR_NEW_STORY = 'CLEAR_NEW_STORY';
+export const TOGGLE_MODE = 'TOGGLE_MODE';
 
 interface MoveStories {
   sourceState: string;
@@ -46,4 +47,9 @@ export const editStory = (story: Story): AnyAction => ({
 export const moveStory = (payload: MoveStories): AnyAction => ({
   type: MOVE_STORY,
   ...payload,
+});
+
+export const toggleMode = (mode: string): AnyAction => ({
+  type: TOGGLE_MODE,
+  mode,
 });

--- a/redux/reducers/stories.ts
+++ b/redux/reducers/stories.ts
@@ -4,10 +4,8 @@ import {
   ADD_STORIES,
   CLEAR_NEW_STORY,
   EDIT_STORY,
-  MOVE_STORY,
   NEW_STORY,
   SAVED_NEW_STORY,
-  TOGGLE_MODE,
 } from '../actions/stories.actions';
 import { StoriesState, Story } from '../types';
 import byProjectReducer from './stories/byProject';

--- a/redux/reducers/stories.ts
+++ b/redux/reducers/stories.ts
@@ -7,6 +7,7 @@ import {
   MOVE_STORY,
   NEW_STORY,
   SAVED_NEW_STORY,
+  TOGGLE_MODE,
 } from '../actions/stories.actions';
 import { StoriesState, Story } from '../types';
 import byProjectReducer from './stories/byProject';
@@ -89,15 +90,11 @@ const reducer = (state: StoriesState = initialState, action: AnyAction) => {
         }),
       };
     }
-
-    case MOVE_STORY: {
+    default:
       return {
         ...state,
         byProject: byProjectReducer(state.byProject, actionWithProjectId),
       };
-    }
-    default:
-      return state;
   }
 };
 

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -1,6 +1,11 @@
 import { AnyAction } from 'redux';
 
-import { STORIES_BY_MILESTONE, STORIES_BY_STATE, STORY_MILESTONES } from '../../../constants';
+import {
+  STORIES_BY_MILESTONE,
+  STORIES_BY_STATE,
+  STORY_MILESTONES,
+  STORY_STATES,
+} from '../../../constants';
 import {
   ADD_STORIES,
   CLEAR_NEW_STORY,
@@ -30,13 +35,34 @@ const getStoryMilestone = (story: Story): string => {
 const reducer = (state: Record<string, StoriesByProject> = initialState, action: AnyAction) => {
   switch (action.type) {
     case NEW_STORY: {
+      const selectedMode = state[action.projectId].selectedMode;
+
+      console.log('got selected mode', selectedMode);
+
+      let storyIdsByState = state[action.projectId].storyIdsByState;
+      let storyIdsByMilestone = state[action.projectId].storyIdsByMilestone;
+
+      if (selectedMode === 'Milestone') {
+        storyIdsByMilestone = {
+          ...storyIdsByMilestone,
+          [STORY_MILESTONES[0]]: ['pending', ...storyIdsByMilestone[STORY_MILESTONES[0]]],
+        };
+      } else {
+        console.log('got storyIdsByState', storyIdsByState, storyIdsByState[STORY_STATES[0]]);
+        storyIdsByState = {
+          ...(storyIdsByState = {
+            ...storyIdsByState,
+            [STORY_STATES[0]]: ['pending', ...storyIdsByState[STORY_STATES[0]]],
+          }),
+        };
+      }
+
       return {
         ...state,
         [action.projectId]: {
-          storyIdsByState: {
-            ...state[action.projectId].storyIdsByState,
-            unscheduled: ['pending', ...state[action.projectId].storyIdsByState.unscheduled],
-          },
+          ...state[action.projectId],
+          storyIdsByState,
+          storyIdsByMilestone,
         },
       };
     }
@@ -60,10 +86,21 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
       return {
         ...state,
         [action.projectId]: {
+          ...state[action.projectId],
           storyIdsByState: {
             ...state[action.projectId].storyIdsByState,
-            unscheduled: [
-              ...state[action.projectId].storyIdsByState.unscheduled.filter(id => id !== 'pending'),
+            [STORY_STATES[0]]: [
+              ...state[action.projectId].storyIdsByState[STORY_STATES[0]].filter(
+                id => id !== 'pending'
+              ),
+            ],
+          },
+          storyIdsByMilestone: {
+            ...state[action.projectId].storyIdsByMilestone,
+            [STORY_MILESTONES[0]]: [
+              ...state[action.projectId].storyIdsByMilestone[STORY_MILESTONES[0]].filter(
+                id => id !== 'pending'
+              ),
             ],
           },
         },

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -35,9 +35,9 @@ const getStoryMilestone = (story: Story): string => {
 const reducer = (state: Record<string, StoriesByProject> = initialState, action: AnyAction) => {
   switch (action.type) {
     case NEW_STORY: {
-      const selectedMode = state[action.projectId].selectedMode;
-      const idArrayName = selectedMode === 'Milestone' ? 'storyIdsByMilestone' : 'storyIdsByState';
-      const startingState = selectedMode === 'Milestone' ? STORY_MILESTONES[0] : STORY_STATES[0];
+      const isMilestoneMode = state[action.projectId].selectedMode === 'Milestone';
+      const idArrayName = isMilestoneMode ? 'storyIdsByMilestone' : 'storyIdsByState';
+      const startingState = isMilestoneMode ? STORY_MILESTONES[0] : STORY_STATES[0];
 
       return {
         ...state,

--- a/redux/reducers/stories/byProject.ts
+++ b/redux/reducers/stories/byProject.ts
@@ -37,8 +37,6 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
     case NEW_STORY: {
       const selectedMode = state[action.projectId].selectedMode;
 
-      console.log('got selected mode', selectedMode);
-
       let storyIdsByState = state[action.projectId].storyIdsByState;
       let storyIdsByMilestone = state[action.projectId].storyIdsByMilestone;
 
@@ -68,16 +66,26 @@ const reducer = (state: Record<string, StoriesByProject> = initialState, action:
     }
     case SAVED_NEW_STORY: {
       //clears the the story new story as well as adds a new story into state.
-      const unscheduledStories = state[action.projectId].storyIdsByState.unscheduled.filter(
-        id => id !== 'pending'
-      );
+      const storyIdsByState = state[action.projectId].storyIdsByState;
+      const storyIdsByMilestone = state[action.projectId].storyIdsByMilestone;
 
       return {
         ...state,
         [action.projectId]: {
+          ...state[action.projectId],
           storyIdsByState: {
-            ...state[action.projectId].storyIdsByState,
-            unscheduled: [action.story.id, ...unscheduledStories],
+            ...storyIdsByState,
+            [STORY_STATES[0]]: [
+              action.story.id,
+              ...storyIdsByState[STORY_STATES[0]].filter(id => id !== 'pending'),
+            ],
+          },
+          storyIdsByMilestone: {
+            ...storyIdsByMilestone,
+            [STORY_MILESTONES[0]]: [
+              action.story.id,
+              ...storyIdsByMilestone[STORY_MILESTONES[0]].filter(id => id !== 'pending'),
+            ],
           },
         },
       };

--- a/redux/store.ts
+++ b/redux/store.ts
@@ -1,6 +1,6 @@
 // store.ts
 import { Context, createWrapper, MakeStore } from 'next-redux-wrapper';
-import { AnyAction, combineReducers, createStore } from 'redux';
+import { combineReducers, createStore } from 'redux';
 
 import iterations from './reducers/iterations';
 import projects from './reducers/projects';

--- a/redux/types.ts
+++ b/redux/types.ts
@@ -18,9 +18,15 @@ export interface StoriesState {
   selectedProjectId?: string;
 }
 
+export enum StoryModes {
+  State = 'State',
+  Milestone = 'Milestone',
+}
+
 export interface StoriesByProject {
+  selectedMode: StoryModes;
   storyIdsByState: Record<string, string[]>;
-  // storyIdsByMilestone: Record<string, string[]>;
+  storyIdsByMilestone: Record<string, string[]>;
 }
 
 export interface Project {


### PR DESCRIPTION
The concept is to have a 'Milestone View' where we can use for estimating projects. Crazily enough because this is just a different organization of the way we view tickets, it shouldn't require too many UI changes.

The concept for this view is when we're at the very beginning of a project, we would like to group different tickets by milestones (which end up being labels in pivotal).

For now I've made the milestones static for our needs, but a future PR could probably have these be dynamic. You'll see in this PR this is almost exclusively state changes, and very little visual, the power of redux!

Todos:
- [X] Create a list of stories ids by milestone
- [X] Update list of milestones when pulling down stories
- [X] Add a 'mode' for which view we are viewing the board in, stories or milestones
- [X] Update Add new story to respect mode
- [X] Make sure we can cancel when adding a new story
- [X] Saving a new story should save to both first phases of each mode.
- [X] Dragging and dropping should add Tags for correct mode in Milestone View