### PR TITLE
Fixed story description saving bug

### DIFF
--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -6,7 +6,6 @@ import { getTheme } from '../redux/selectors/settings.selectors';
 interface MarkdownEditorParams {
   defaultValue: string;
   placeholder: string;
-  onSave?: () => void;
   onChange: (description: string) => void;
 }
 
@@ -30,11 +29,6 @@ const MarkdownEditor = ({
       onChange={value => {
         const changedValue = value();
         onChange(changedValue);
-      }}
-      handleDOMEvents={{
-        blur: () => {
-          return true;
-        },
       }}
       theme={{ ...markdownTheme, zIndex: 10000 }}
     />

--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -6,7 +6,7 @@ import { getTheme } from '../redux/selectors/settings.selectors';
 interface MarkdownEditorParams {
   defaultValue: string;
   placeholder: string;
-  onSave: () => void;
+  onSave?: () => void;
   onChange: (description: string) => void;
 }
 
@@ -15,7 +15,6 @@ import { dark, light } from 'rich-markdown-editor/dist/theme';
 const MarkdownEditor = ({
   defaultValue,
   placeholder,
-  onSave,
   onChange,
 }: MarkdownEditorParams): JSX.Element => {
   const globalTheme = useSelector(getTheme);
@@ -34,7 +33,6 @@ const MarkdownEditor = ({
       }}
       handleDOMEvents={{
         blur: () => {
-          onSave();
           return true;
         },
       }}

--- a/components/StoryModal.tsx
+++ b/components/StoryModal.tsx
@@ -43,17 +43,24 @@ const StoryModal = (): JSX.Element => {
       payload: { description },
     });
     dispatch(editStory(newStory));
+    setDescription('');
   });
 
+  const handleClose = () => {
+    if (description) {
+      saveDescription();
+    }
+    dispatch(deselectStory());
+  };
+
   return (
-    <Modal open={isOpen} key={story?.id} width="60%" onClose={() => dispatch(deselectStory())}>
+    <Modal open={isOpen} key={story?.id} width="60%" onClose={() => handleClose()}>
       <Modal.Title>{story?.name}</Modal.Title>
       <Modal.Content>
         <Section title="Description">
           <MarkdownEditor
             defaultValue={story?.description}
             placeholder="Add something..."
-            onSave={saveDescription}
             onChange={value => setDescription(value)}
           />
         </Section>


### PR DESCRIPTION
**Type:** Bugfix
**Related:** [175422808](https://www.pivotaltracker.com/n/projects/2463484/stories/175422808) and [175422148](https://www.pivotaltracker.com/n/projects/2463484/stories/175422148)

**Problem:** description was saving correctly on markdown input blur, but if modal was closed directly saving failed.

To fix this weird behavior, description is now saved on modal close and state is cleared to avoid older values on new editions.