### PR TITLE
new story crash cases

### DIFF
--- a/handlers/PivotalHandler.ts
+++ b/handlers/PivotalHandler.ts
@@ -95,17 +95,14 @@ class PivotalHandler {
   }
 
   static async addComment({ apiKey, projectId, storyId, text }): Promise<void> {
-    await fetch(
-      `${PIVOTAL_API_URL}/projects/${projectId}/stories/${storyId}/comments?${STORY_FIELDS}`,
-      {
-        method: 'POST',
-        headers: {
-          'X-TrackerToken': apiKey,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ text }),
-      }
-    );
+    await fetch(`${PIVOTAL_API_URL}/projects/${projectId}/stories/${storyId}/comments`, {
+      method: 'POST',
+      headers: {
+        'X-TrackerToken': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text }),
+    });
   }
 }
 export default PivotalHandler;

--- a/handlers/PivotalHandler.ts
+++ b/handlers/PivotalHandler.ts
@@ -51,14 +51,17 @@ class PivotalHandler {
   // Updates a single story.
   static async updateStory({ apiKey, projectId, storyId, payload }): Promise<Story> {
     if (storyId === 'pending') {
-      const response = await fetch(`${PIVOTAL_API_URL}/projects/${projectId}/stories`, {
-        method: 'POST',
-        headers: {
-          'X-TrackerToken': apiKey,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ ...payload }),
-      });
+      const response = await fetch(
+        `${PIVOTAL_API_URL}/projects/${projectId}/stories?${STORY_FIELDS}`,
+        {
+          method: 'POST',
+          headers: {
+            'X-TrackerToken': apiKey,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ ...payload }),
+        }
+      );
       return response.json();
     }
 
@@ -92,14 +95,17 @@ class PivotalHandler {
   }
 
   static async addComment({ apiKey, projectId, storyId, text }): Promise<void> {
-    await fetch(`${PIVOTAL_API_URL}/projects/${projectId}/stories/${storyId}/comments`, {
-      method: 'POST',
-      headers: {
-        'X-TrackerToken': apiKey,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ text }),
-    });
+    await fetch(
+      `${PIVOTAL_API_URL}/projects/${projectId}/stories/${storyId}/comments?${STORY_FIELDS}`,
+      {
+        method: 'POST',
+        headers: {
+          'X-TrackerToken': apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ text }),
+      }
+    );
   }
 }
 export default PivotalHandler;

--- a/redux/reducers/selectedStory.ts
+++ b/redux/reducers/selectedStory.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from 'redux';
 
 import { DESELECT_STORY, SELECT_STORY } from '../actions/selectedStory.actions';
+import { SAVED_NEW_STORY } from '../actions/stories.actions';
 import { SelectedStory } from '../types';
 
 const initalState = {
@@ -13,6 +14,13 @@ const reducer = (state: SelectedStory = initalState, action: AnyAction): Selecte
       return { selected: true, storyId: action.story.id };
     case DESELECT_STORY: {
       return { selected: false };
+    }
+    case SAVED_NEW_STORY: {
+      //** If the modal was open for pending and it was updated to a saved state, update to that storyId */
+      if (state.selected && state.storyId === 'pending') {
+        return { selected: true, storyId: action.story.id };
+      }
+      return state;
     }
     default:
       return state;


### PR DESCRIPTION
Alexis identified two cases where creating a new story would crash.

1. Creating a new story and pressing enter, then opening the modal would crash. This was because we were not specifying the story fields to return and we were crashing with no empty comments array.

2. Opening a modal on pending would crash when that story became null (after it was saved). I added a redux case to update to the new story in this case and it fixed the issue.

Ticket Id: https://www.pivotaltracker.com/story/show/175422793