### PR TITLE
Ensure object-path is upgraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "rich-markdown-editor": "^11.0.2",
     "styled-components": "^5.1.1"
   },
+  "resolutions": {
+    "object-path": "^0.11.5"
+  },
   "devDependencies": {
     "@types/node": "^14.6.0",
     "@types/react": "^16.9.47",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4776,10 +4776,10 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
-  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
+object-path@0.11.4, object-path@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
+  integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
 
 object-visit@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Upgrades object-path because of dependabot: https://github.com/opticpower/tracker/network/alerts