### PR TITLE
Add people to state

### DIFF
--- a/handlers/PivotalHandler.ts
+++ b/handlers/PivotalHandler.ts
@@ -11,11 +11,14 @@ const STORY_FIELDS =
 class PivotalHandler {
   // Gets all projects for the provided user apiKey.
   static async fetchProjects({ apiKey }): Promise<Project[]> {
-    const response = await fetch('https://www.pivotaltracker.com/services/v5/projects', {
-      headers: {
-        'X-TrackerToken': apiKey,
-      },
-    });
+    const response = await fetch(
+      'https://www.pivotaltracker.com/services/v5/projects?fields=id,name,memberships',
+      {
+        headers: {
+          'X-TrackerToken': apiKey,
+        },
+      }
+    );
 
     return await response.json();
   }

--- a/redux/reducers/projects.ts
+++ b/redux/reducers/projects.ts
@@ -1,13 +1,20 @@
-import { Project } from '../types';
 import { AnyAction } from 'redux';
+
 import { ADD_PROJECTS } from '../actions/projects.actions';
+import { Project } from '../types';
 
 const initialState = [];
 
 const reducer = (state: Project[] = initialState, action: AnyAction) => {
   switch (action.type) {
     case ADD_PROJECTS:
-      return [...action.projects];
+      return [
+        ...action.projects.map(project => ({
+          id: project.id,
+          name: project.name,
+          people: project.memberships.map(membership => membership.person),
+        })),
+      ];
     default:
       return state;
   }

--- a/redux/types.ts
+++ b/redux/types.ts
@@ -32,6 +32,7 @@ export interface StoriesByProject {
 export interface Project {
   id: string;
   name: string;
+  people: Owner[];
 }
 
 export interface SelectedStory {


### PR DESCRIPTION
This is a pre-requisite for being able to assign/unassign people, but it will give us each of the 'people' involved at the project level. We'll be able to use this to display things like a picker to select which person to assign the task to when we want to do task selection.