### PR TITLE
Change story type

### DIFF
--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -65,7 +65,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [name, setName] = useState<string>(story.name);
-  const [type, setType] = useState<string>(story.story_type);
+  const [type, setType] = useState<string | string[]>(story.story_type);
   const escape = useRef(false); // we can't use setState for this as the dispatch of this takes an extra tick.
 
   const [_, saveName] = usePivotal(async ({ apiKey, projectId }) => {
@@ -117,7 +117,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     setIsModalVisible(true);
   };
 
-  const StoryTypeSelect = () => {
+  const StoryTypeSelect = (): JSX.Element => {
     return (
       <Select
         placeholder="Type"

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -1,5 +1,5 @@
 import { Badge, Breadcrumbs, Card, Divider, Select, Spacer } from '@geist-ui/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
@@ -95,7 +95,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     }
   });
 
-  const [fn, saveStoryType] = usePivotal(async ({ apiKey, projectId }) => {
+  const [val, saveStoryType] = usePivotal(async ({ apiKey, projectId }) => {
     if (story.story_type !== type) {
       const newStory = await PivotalHandler.updateStory({
         apiKey,
@@ -108,6 +108,10 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     }
   });
 
+  useEffect(() => {
+    saveStoryType();
+  }, [type]);
+
   const openEstimationModal = (e): void => {
     e.stopPropagation();
     setIsModalVisible(true);
@@ -117,7 +121,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     return (
       <Select
         placeholder="Type"
-        value="feature"
+        value={type}
         size="mini"
         onChange={value => {
           setType(value);
@@ -162,7 +166,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
                   </div>
                 )}
                 <Breadcrumbs size="mini">
-                  {story.id === 'pending' || story.current_state === 'unscheduled' ? (
+                  {story.id === 'pending' || state === 'unscheduled' ? (
                     <StoryTypeSelect />
                   ) : (
                     <StoryType color={typeColors[story.story_type]}>{story.story_type}</StoryType>

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -123,6 +123,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
         placeholder="Type"
         value={type}
         size="mini"
+        disabled={story.id === 'pending'}
         onChange={value => {
           setType(value);
           saveStoryType();

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -1,10 +1,10 @@
-import { Badge, Breadcrumbs, Card, Divider, Select, Spacer } from '@geist-ui/react';
+import { Badge, Breadcrumbs, Card, Divider, Spacer } from '@geist-ui/react';
 import { useEffect, useRef, useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
-import { STORY_TYPES, UNESTIMATED_STORY_TYPES } from '../constants';
+import { UNESTIMATED_STORY_TYPES } from '../constants';
 import PivotalHandler from '../handlers/PivotalHandler';
 import { usePivotal } from '../hooks';
 import { selectStory } from '../redux/actions/selectedStory.actions';
@@ -14,6 +14,7 @@ import BlockersQuickView from './BlockersQuickView';
 import EstimateChangeDialog from './Dialogs/EstimateChangeDialog';
 import Labels from './Labels';
 import Owners from './Owners';
+import StoryTypeSelect from './StoryTypeSelect';
 
 const CardContainer = styled(Card)(({ color }) => ({
   position: 'relative',
@@ -65,7 +66,7 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [name, setName] = useState<string>(story.name);
-  const [type, setType] = useState<string | string[]>(story.story_type);
+  const [type, setType] = useState<string>(story.story_type);
   const escape = useRef(false); // we can't use setState for this as the dispatch of this takes an extra tick.
 
   const [_, saveName] = usePivotal(async ({ apiKey, projectId }) => {
@@ -117,27 +118,6 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
     setIsModalVisible(true);
   };
 
-  const StoryTypeSelect = (): JSX.Element => {
-    return (
-      <Select
-        placeholder="Type"
-        value={type}
-        size="mini"
-        disabled={story.id === 'pending'}
-        onChange={value => {
-          setType(value);
-          saveStoryType();
-        }}
-        width="80px">
-        {STORY_TYPES.map(type => (
-          <Select.Option key={type} value={type}>
-            {type}
-          </Select.Option>
-        ))}
-      </Select>
-    );
-  };
-
   return (
     <>
       <Draggable draggableId={story.id.toString()} index={index}>
@@ -168,7 +148,12 @@ const StoryCard = ({ story, state, index, addFilter }: StoryCardParams): JSX.Ele
                 )}
                 <Breadcrumbs size="mini">
                   {story.id === 'pending' || state === 'unscheduled' ? (
-                    <StoryTypeSelect />
+                    <StoryTypeSelect
+                      type={type}
+                      story={story}
+                      setType={setType}
+                      saveStoryType={saveStoryType}
+                    />
                   ) : (
                     <StoryType color={typeColors[story.story_type]}>{story.story_type}</StoryType>
                   )}

--- a/components/StoryTypeSelect.tsx
+++ b/components/StoryTypeSelect.tsx
@@ -1,0 +1,39 @@
+import { Select } from '@geist-ui/react';
+
+import { STORY_TYPES } from '../constants';
+import { Story } from '../redux/types';
+
+interface StoryTypeSelectProps {
+  type: string;
+  story: Story;
+  setType: (value: string) => void;
+  saveStoryType: () => void;
+}
+
+const StoryTypeSelect = ({
+  type,
+  story,
+  setType,
+  saveStoryType,
+}: StoryTypeSelectProps): JSX.Element => {
+  return (
+    <Select
+      placeholder="Type"
+      value={type}
+      size="mini"
+      disabled={story.id === 'pending'}
+      onChange={value => {
+        setType(Array.isArray(value) ? value[0] : value);
+        saveStoryType();
+      }}
+      width="80px">
+      {STORY_TYPES.map(type => (
+        <Select.Option key={type} value={type}>
+          {type}
+        </Select.Option>
+      ))}
+    </Select>
+  );
+};
+
+export default StoryTypeSelect;

--- a/constants.js
+++ b/constants.js
@@ -17,6 +17,8 @@ export const STORIES_BY_MILESTONE = STORY_MILESTONES.reduce(
   {}
 );
 
+export const STORY_TYPES = ['feature', 'bug', 'chore', 'release'];
+
 export const UNESTIMATED_STORY_TYPES = ['bug', 'chore'];
 
 export const ESTIMATE_NOT_REQUIRED_STATES = ['unstarted', 'unscheduled'];


### PR DESCRIPTION
Based on a talk with Alexis yesterday, we discussed about this feature request: [175295009](https://www.pivotaltracker.com/n/projects/2463484/stories/175295009).

Changing the type is not that easy for ongoing/finished stories because estimations and status are changed or deleted, so several validations need to be done and discussed.

The first MVP I'm working on is the possibility of select/change the type when story is in the unscheduled column, typically when you are creating it.

@mattvv What do you think of this first try? Still super buggy
