### PR TITLE
fix: removed editor key prop to avoid unmounting on change

### DIFF
--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -22,7 +22,6 @@ const MarkdownEditor = ({
 
   return (
     <Editor
-      key={defaultValue}
       defaultValue={defaultValue}
       placeholder={placeholder}
       dark={globalTheme === 'dark'}


### PR DESCRIPTION
Checking master I saw markdown editor was broken. 
The problem was that markdown editor was unmounting on every change, because it receives the changed value as key.
I removed key prop from editor as it seems it's not required.