### PR TITLE
Fixing some UI styles

### DIFF
--- a/components/StoryModal.tsx
+++ b/components/StoryModal.tsx
@@ -20,6 +20,11 @@ import Reviews from './Reviews';
 
 const EDITABLE_FIELDS = ['description', 'owners', 'labels', 'reviews'];
 
+// Used to override Modal.Content's default margin
+const ModalContent = styled(Modal.Content)`
+  margin: unset !important;
+`;
+
 const SectionContainer = styled.div`
   &:not(last-child) {
     margin-bottom: 24px;
@@ -136,7 +141,7 @@ const StoryModal = (): JSX.Element => {
   return (
     <Modal open={isOpen} key={story?.id} width="60%" onClose={() => handleClose()}>
       <Modal.Title>{story?.name}</Modal.Title>
-      <Modal.Content>
+      <ModalContent>
         <Section title="Description">
           <MarkdownEditor
             defaultValue={editedFields.description}
@@ -174,7 +179,7 @@ const StoryModal = (): JSX.Element => {
         <Blockers blockers={story?.blockers} blockedStoryIds={story?.blocked_story_ids} />
         <Divider>Comments</Divider>
         <Comments story={story} />
-      </Modal.Content>
+      </ModalContent>
     </Modal>
   );
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,11 +3,17 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
 
 import { redirectIfApiKeyExists } from '../redirects';
 import { setApiKey } from '../redux/actions/settings.actions';
 import { getApiKey } from '../redux/selectors/settings.selectors';
 import { wrapper } from '../redux/store';
+
+const StyledSpan = styled.span`
+  text-decoration: underline;
+  cursor: pointer;
+`;
 
 const Home = () => {
   const [key, setKey] = useState('');
@@ -31,7 +37,9 @@ const Home = () => {
       <Card shadow>
         <Note type="success">
           To get your API Token, go to{' '}
-          <a href="https://www.pivotaltracker.com/profile">Your pivotal profile</a>
+          <a href="https://www.pivotaltracker.com/profile">
+            Your pivotal <StyledSpan>profile</StyledSpan>
+          </a>
         </Note>
         <Spacer y={1} />
         Please input your pivotal token below:


### PR DESCRIPTION
### Description
This PR will fix some UI styles.

Now when the user hovers the `profile` word the cursor will appear. I also underline the word to make it look like a link.
**Before**
<img width="1013" alt="Screen Shot 2021-02-17 at 6 31 57 PM" src="https://user-images.githubusercontent.com/22966249/108288159-1d72f300-715a-11eb-839c-db45eb309d35.png">

**After**
<img width="1000" alt="Screen Shot 2021-02-17 at 7 45 46 PM" src="https://user-images.githubusercontent.com/22966249/108288180-24016a80-715a-11eb-924f-f65f96ea45eb.png">

Now the `+` are more visible.
**Before**
<img width="923" alt="Screen Shot 2021-02-17 at 7 41 47 PM" src="https://user-images.githubusercontent.com/22966249/108288222-3b405800-715a-11eb-9028-569860403474.png">

**After**
<img width="896" alt="Screen Shot 2021-02-17 at 7 44 55 PM" src="https://user-images.githubusercontent.com/22966249/108288258-48f5dd80-715a-11eb-8b64-58525357823a.png">

